### PR TITLE
Close #16. Symfony reverse proxy used for all 'read' methods.

### DIFF
--- a/.env
+++ b/.env
@@ -14,7 +14,7 @@
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 
 ###> symfony/framework-bundle ###
-APP_ENV=dev
+APP_ENV=prod
 APP_DEBUG=3
 APP_SECRET=40752e07e8fe535ed65989bac6aa2c10
 #TRUSTED_PROXIES=127.0.0.1,127.0.0.2

--- a/public/index.php
+++ b/public/index.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Kernel;
+use App\CacheKernel;
 use Symfony\Component\Debug\Debug;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -21,6 +22,12 @@ if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false
 }
 
 $kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+
+// Wrap the default Kernel with the CacheKernel one in 'prod' environment
+if ('prod' === $kernel->getEnvironment()) {
+    $kernel = new CacheKernel($kernel);
+}
+
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();

--- a/src/CacheKernel.php
+++ b/src/CacheKernel.php
@@ -1,0 +1,10 @@
+<?php
+// src/CacheKernel.php
+
+namespace App;
+
+use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
+
+class CacheKernel extends HttpCache
+{
+}

--- a/src/Controller/EndUserController.php
+++ b/src/Controller/EndUserController.php
@@ -7,23 +7,22 @@ use App\Exception\ResourceValidationException;
 use App\Exception\ResourceNotFoundException;
 use App\Exception\ResourceAccessNotAuthorized;
 use App\Representation\EndUsers;
-use Symfony\Component\HttpFoundation\Response;
 use FOS\RestBundle\Controller\Annotations as Rest;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use FOS\RestBundle\Controller\FOSRestController;
+use FOS\RestBundle\Controller\AbstractFOSRestController;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use FOS\OAuthServerBundle\Model\AccessTokenManagerInterface as ATM;
+use App\Tools\Tools;
 
 /**
  * EndUser controller.
  * @Route("/api", name="api_")
  */
-class EndUserController extends FOSRestController
+class EndUserController extends AbstractFOSRestController
 {
     // Access token manager
     private $atm;
@@ -91,18 +90,7 @@ class EndUserController extends FOSRestController
             $paramFetcher->get('page')
         );
 
-        $response = new Response();
-
-        // Cache for 600 seconds
-        $response->setSharedMaxAge(600);
-
-        // (optional) set a custom Cache-Control directive
-        $response->headers->addCacheControlDirective('must-revalidate', true);
-
-        $view = $this->view(new EndUsers($pager));
-        $view->setResponse($response);
-    
-        return $this->handleView($view);
+        return Tools::setCache($this, 300, new EndUsers($pager));
     }
 
     // We use a custom ParamConverter:
@@ -119,7 +107,7 @@ class EndUserController extends FOSRestController
     {
         self::checkEndUserOwner($endUser);
 
-        return $endUser;
+        return Tools::setCache($this, 600, $endUser);
     }
 
     /**

--- a/src/Controller/EndUserController.php
+++ b/src/Controller/EndUserController.php
@@ -7,6 +7,7 @@ use App\Exception\ResourceValidationException;
 use App\Exception\ResourceNotFoundException;
 use App\Exception\ResourceAccessNotAuthorized;
 use App\Representation\EndUsers;
+use Symfony\Component\HttpFoundation\Response;
 use FOS\RestBundle\Controller\Annotations as Rest;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
@@ -90,7 +91,18 @@ class EndUserController extends FOSRestController
             $paramFetcher->get('page')
         );
 
-        return new EndUsers($pager);
+        $response = new Response();
+
+        // Cache for 600 seconds
+        $response->setSharedMaxAge(600);
+
+        // (optional) set a custom Cache-Control directive
+        $response->headers->addCacheControlDirective('must-revalidate', true);
+
+        $view = $this->view(new EndUsers($pager));
+        $view->setResponse($response);
+    
+        return $this->handleView($view);
     }
 
     // We use a custom ParamConverter:

--- a/src/Controller/ProductController.php
+++ b/src/Controller/ProductController.php
@@ -12,6 +12,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use FOS\RestBundle\Controller\AbstractFOSRestController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use App\Tools\Tools;
 use Psr\Log\LoggerInterface;
 
 //use Hateoas\Representation\PaginatedRepresentation;
@@ -59,7 +60,7 @@ class ProductController extends AbstractFOSRestController
             $paramFetcher->get('page')
         );
 
-        return new Products($pager);
+        return Tools::setCache($this, 3600, new Products($pager));
     }
 
     // We use a custom ParamConverter:
@@ -74,6 +75,6 @@ class ProductController extends AbstractFOSRestController
      */
     public function show(Product $product)
     {
-        return $product;
+        return Tools::setCache($this, 3600, $product);
     }
 }

--- a/src/Tools/Tools.php
+++ b/src/Tools/Tools.php
@@ -3,8 +3,29 @@
 
 namespace App\Tools;
 
-class Tools
+use Symfony\Component\HttpFoundation\Response;
+use FOS\RestBundle\Controller\AbstractFOSRestController;
+
+// Extending AbstractFOSRestController to be able to use
+// AbstractFOSRestController::view() protected method.
+class Tools extends AbstractFOSRestController
 {
+    public function setCache($fosRestObject, $maxAge, $objForView)
+    {
+        $response = new Response();
+
+        // Cache for 3600 seconds
+        $response->setSharedMaxAge($maxAge);
+
+        // Set a custom Cache-Control directive
+        $response->headers->addCacheControlDirective('must-revalidate', true);
+
+        $view = $fosRestObject->view($objForView);
+        $view->setResponse($response);
+    
+        return $fosRestObject->handleView($view);
+    }
+
     public function getRandAlphaNumStr($len = 10)
     {
         $chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';


### PR DESCRIPTION
The Symfony reverse proxy is now used for these routes:

- api_end_user_list
- api_end_user_show
- api_product_list
- api_product_show

Tests done. Performance improved.