### PR TITLE
Close #20. API access forced on HTTPS

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -40,7 +40,5 @@ security:
             anonymous: true
 
     access_control:
-        - { path: ^/api, roles: [ IS_AUTHENTICATED_FULLY ] }
-        - { path: ^/createClient, roles: [ IS_AUTHENTICATED_ANONYMOUSLY ] }
-        #- { path: ^/api, roles: [ IS_AUTHENTICATED_FULLY ], requires_channel: https }
-        #- { path: ^/createClient, roles: [ IS_AUTHENTICATED_ANONYMOUSLY ], requires_channel: https }
+        #- { path: ^/api, roles: [ IS_AUTHENTICATED_FULLY ] }
+        - { path: ^/api, roles: [ IS_AUTHENTICATED_FULLY ], requires_channel: https }


### PR DESCRIPTION
Symfony security settings modified to force HTTPS to access the API (in security.yaml).