### PR TITLE
Close #32. screenSize decimal value fixed

### DIFF
--- a/src/Entity/Product.php
+++ b/src/Entity/Product.php
@@ -47,7 +47,7 @@ class Product
     private $memCapacity;
 
     /**
-     * @ORM\Column(type="float")
+     * @ORM\Column(type="decimal", precision=2, scale=1)
      */
     private $screenSize;
 


### PR DESCRIPTION
float type replaced with:
type="decimal", precision=2, scale=1
screenSize value stored in the database by fixtures is now correct.