### PR TITLE
Close #45. limit max value set to 20. Error message added.

### DIFF
--- a/src/Repository/AbstractRepository.php
+++ b/src/Repository/AbstractRepository.php
@@ -28,6 +28,12 @@ abstract class AbstractRepository extends EntityRepository
             throw new LimitOrPageLogicException($message);
         }
 
+        if (!(filter_var($limit, FILTER_VALIDATE_INT) && 20 >= $limit)) {
+            $message = '$limit maximum accepted value is 20.';
+
+            throw new LimitOrPageLogicException($message);
+        }
+
         if (!(filter_var($page, FILTER_VALIDATE_INT) && 0 < $page)) {
             $message = '$page must be an integer greater than 0.';
 


### PR DESCRIPTION
The pagination 'limit' maximum accepted value is set to 20.
A relevant error message is added.